### PR TITLE
Add requiresMainQueueSetup method implementation

### DIFF
--- a/src/ios/SQLite.m
+++ b/src/ios/SQLite.m
@@ -72,6 +72,11 @@ RCT_EXPORT_MODULE();
 @synthesize openDBs;
 @synthesize appDBPaths;
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 - (id) init
 {
   NSLog(@"Initializing SQLitePlugin");


### PR DESCRIPTION
It fixes following warning on iOS. Please merge. Similar commit was also appended into original repository - https://github.com/andpor/react-native-sqlite-storage/pull/262/commits/f0bcdcc57012155fb24b0e85f88d850e71a00475
![image](https://user-images.githubusercontent.com/39645529/103273293-5f907b80-49d8-11eb-9c30-de52a3bfff00.png)
