### PR TITLE
Ensure source tag refers to uri that doesn't change after each install

### DIFF
--- a/react-native-sqlcipher-storage.podspec
+++ b/react-native-sqlcipher-storage.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source = { :git => "file://#{__dir__}"}
+  s.source = { :git => "https://github.com/axsy-dev/react-native-sqlcipher-storage.git"}
   s.source_files  = "ios/*.{h,m}"
 
   s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SQLITE_HAS_CODEC=1' }


### PR DESCRIPTION
I think this could be the reason this Pod always changes.

Cocoapods checks the podspec with something like `pod ipc spec ../node_modules/react-native-sqlcipher-storage/react-native-sqlcipher-storage.podspec | openssl sha`.

The line in the podspec `"file://#{__dir__}"}` is the full absolute path to this directory and will therefore be different for each person installing this package.