### PR TITLE
Fix deprecated maven plugin and remove duplication

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ def safeExtGet(prop, fallback) {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -38,9 +38,6 @@ buildscript {
         }
     }
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)


### PR DESCRIPTION
The maven plugin has been deprecated; maven-publish is preferred.

This is a required change for upgrading to react-native 0.72 with Gradle 8.0.1